### PR TITLE
EID-208: Update to use latest version of dropwizard saml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
     }
 
     dependencies {
-        common "uk.gov.ida:dropwizard-saml:$opensaml_version-357",
+        common "uk.gov.ida:dropwizard-saml:$opensaml_version-361",
                 "org.opensaml:opensaml-core:$opensaml_version",
                 "uk.gov.verify:saml-utils:$opensaml_version-33",
                 'com.google.guava:guava:18.0',


### PR DESCRIPTION
This is required for making eidasEntityId as an optional configuration item for saml-engine, saml-proxy amd saml-soap-proxy.

Solo: @adityapahuja