### PR TITLE
TT-983: remove address_history_verified attribute

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
@@ -18,7 +18,6 @@ public enum UserAccountCreationAttribute implements Serializable {
     CURRENT_ADDRESS("currentaddress"),
     CURRENT_ADDRESS_VERIFIED("currentaddress_verified"),
     ADDRESS_HISTORY("addresshistory"),
-    ADDRESS_HISTORY_VERIFIED("addresshistory_verified"),
     CYCLE_3("cycle_3");
 
     private String attributeName;


### PR DESCRIPTION
The address history attribute will include verified booleans for each address

Authors: @kevingarwood, @hugh-emerson