### PR TITLE
refactor: update saml-utils and delete code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
 
     dependencies {
         common "org.opensaml:opensaml-core:$opensaml_version",
-                "uk.gov.verify:saml-utils:$opensaml_version-66",
+                "uk.gov.verify:saml-utils:$opensaml_version-67",
                 'com.google.guava:guava:18.0',
                 'com.google.inject:guice:4.0',
                 'joda-time:joda-time:2.9',

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
@@ -60,14 +60,10 @@ import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromMatchingServi
 import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
-import uk.gov.ida.saml.hub.validators.response.common.AssertionSizeValidator;
 import uk.gov.ida.saml.hub.transformers.inbound.decorators.AuthnRequestSizeValidator;
-import uk.gov.ida.saml.hub.validators.response.common.ResponseSizeValidator;
-import uk.gov.ida.saml.hub.validators.response.common.ResponseDestinationValidator;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
-import uk.gov.ida.saml.hub.validators.response.idp.IdpResponseValidator;
 import uk.gov.ida.saml.hub.transformers.outbound.AssertionFromIdpToAssertionTransformer;
 import uk.gov.ida.saml.hub.transformers.outbound.AttributeQueryToElementTransformer;
 import uk.gov.ida.saml.hub.transformers.outbound.EidasAuthnRequestFromHubToAuthnRequestTransformer;
@@ -89,16 +85,17 @@ import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestFromTransactionVa
 import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIdKey;
 import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIssueInstantValidator;
 import uk.gov.ida.saml.hub.validators.authnrequest.DuplicateAuthnRequestValidator;
+import uk.gov.ida.saml.hub.validators.response.common.AssertionSizeValidator;
+import uk.gov.ida.saml.hub.validators.response.common.ResponseDestinationValidator;
+import uk.gov.ida.saml.hub.validators.response.common.ResponseSizeValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.IdpResponseValidator;
 import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.HealthCheckResponseFromMatchingServiceValidator;
-import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.ResponseAssertionsFromMatchingServiceValidator;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
-import uk.gov.ida.saml.metadata.domain.HubServiceProviderMetadataDto;
-import uk.gov.ida.saml.metadata.transformers.ContactPersonsUnmarshaller;
 import uk.gov.ida.saml.metadata.transformers.HubIdentityProviderMetadataDtoToEntityDescriptorTransformer;
-import uk.gov.ida.saml.metadata.transformers.OrganizationUnmarshaller;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.CredentialFactorySignatureValidator;
 import uk.gov.ida.saml.security.DecrypterFactory;
@@ -194,10 +191,6 @@ public class HubTransformersFactory {
     public Function<HubIdentityProviderMetadataDto, Element> getHubIdentityProviderMetadataDtoToElementTransformer() {
         return
                 coreTransformersFactory.<EntityDescriptor>getXmlObjectToElementTransformer().compose(getHubIdentityProviderMetadataDtoToEntityDescriptorTransformer());
-    }
-
-    public Function<HubServiceProviderMetadataDto, Element> getHubServiceProviderMetadataDtoToElementTransformer() {
-        return coreTransformersFactory.<EntityDescriptor>getXmlObjectToElementTransformer().compose(new CoreTransformersFactory().getHubServiceProviderMetadataDtoToEntityDescriptorTransformer());
     }
 
     public Function<IdaAuthnRequestFromHub, String> getIdaAuthnRequestFromHubToStringTransformer(IdaKeyStore keyStore, SignatureAlgorithm signatureAlgorithm, DigestAlgorithm digestAlgorithm) {
@@ -436,8 +429,6 @@ public class HubTransformersFactory {
         OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
         return new HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(
                 openSamlXmlObjectFactory,
-                new OrganizationUnmarshaller(openSamlXmlObjectFactory),
-                new ContactPersonsUnmarshaller(openSamlXmlObjectFactory),
                 coreTransformersFactory.getCertificatesToKeyDescriptorsTransformer(),
                 new IdGenerator()
         );

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformer.java
@@ -21,19 +21,13 @@ public class HubIdentityProviderMetadataDtoToEntityDescriptorTransformer impleme
     private final OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
     private final KeyDescriptorsUnmarshaller keyDescriptorsUnmarshaller;
     private final IdGenerator idGenerator;
-    private OrganizationUnmarshaller organizationUnmarshaller;
-    private ContactPersonsUnmarshaller contactPersonsUnmarshaller;
 
     public HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(
         OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
-        OrganizationUnmarshaller organizationUnmarshaller,
-        ContactPersonsUnmarshaller contactPersonsUnmarshaller,
         KeyDescriptorsUnmarshaller keyDescriptorsUnmarshaller,
         IdGenerator idGenerator) {
 
         this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
-        this.organizationUnmarshaller = organizationUnmarshaller;
-        this.contactPersonsUnmarshaller = contactPersonsUnmarshaller;
         this.keyDescriptorsUnmarshaller = keyDescriptorsUnmarshaller;
         this.idGenerator = idGenerator;
     }
@@ -66,14 +60,6 @@ public class HubIdentityProviderMetadataDtoToEntityDescriptorTransformer impleme
         idpSsoDescriptor.getKeyDescriptors().addAll(signingKeyDescriptors);
 
         entityDescriptor.getRoleDescriptors().add(idpSsoDescriptor);
-
-        if (dto.getOrganisation() != null) {
-            final Organization transformedOrganisation = organizationUnmarshaller.fromDto(dto.getOrganisation());
-            entityDescriptor.setOrganization(transformedOrganisation);
-        }
-
-        final List<ContactPerson> transformedContactPersons = contactPersonsUnmarshaller.fromDto(dto.getContactPersons());
-        entityDescriptor.getContactPersons().addAll(transformedContactPersons);
 
         return entityDescriptor;
     }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidator.java
@@ -27,7 +27,6 @@ public class SamlEntityDescriptorValidator {
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
 
-        validateOrganization(descriptor);
         validateRoleDescriptor(descriptor);
     }
 
@@ -66,23 +65,4 @@ public class SamlEntityDescriptorValidator {
         }
     }
 
-    private void validateOrganization(EntityDescriptor descriptor) {
-        Organization organization = descriptor.getOrganization();
-        if (organization == null) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingOrganization();
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
-
-        List<OrganizationDisplayName> displayNames = organization.getDisplayNames();
-        if (displayNames.isEmpty()) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingDisplayName();
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
-
-        String name = displayNames.get(0).getValue();
-        if (name == null) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingDisplayName();
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
-    }
 }

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest.java
@@ -31,7 +31,7 @@ public class HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest {
     @Before
     public void setUp() throws Exception {
         OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
-        transformer = new HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(openSamlXmlObjectFactory, new OrganizationUnmarshaller(openSamlXmlObjectFactory), new ContactPersonsUnmarshaller(openSamlXmlObjectFactory), new KeyDescriptorsUnmarshaller(openSamlXmlObjectFactory), new IdGenerator());
+        transformer = new HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(openSamlXmlObjectFactory, new KeyDescriptorsUnmarshaller(openSamlXmlObjectFactory), new IdGenerator());
     }
 
     @Test

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
@@ -45,36 +45,6 @@ public class SamlEntityDescriptorValidatorTest {
     }
 
     @Test
-    public void decorate_shouldThrowExceptionWhenOrganizationIsMissing() throws Exception {
-        EntityDescriptor entityDescriptor = anEntityDescriptor().withOrganization(null).build();
-
-        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingOrganization());
-    }
-
-    @Test
-    public void decorate_shouldThrowExceptionWhenOrganizationDisplayNameIsMissing() throws Exception {
-        EntityDescriptor entityDescriptor = anEntityDescriptor().withOrganization(anOrganization().withDisplayName(null).build()).build();
-
-        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingDisplayName());
-    }
-
-    @Test
-    public void decorate_shouldThrowExceptionWhenOrganizationDisplayNameNameIsMissing() throws Exception {
-        EntityDescriptor entityDescriptor = anEntityDescriptor().withOrganization(anOrganization().withDisplayName(anOrganizationDisplayName().withName(null).build()).build()).build();
-
-        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingDisplayName());
-
-    }
-
-    @Test
-    public void decorate_shouldThrowExceptionWhenOrganizationDisplayNameNameIsEmpty() throws Exception {
-        EntityDescriptor entityDescriptor = anEntityDescriptor().withOrganization(anOrganization().withDisplayName(anOrganizationDisplayName().withName("").build()).build()).build();
-
-        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingDisplayName());
-
-    }
-
-    @Test
     public void decorate_shouldThrowExceptionWhenRoleDescriptorDoesNotHaveAKeyDescriptorElement() throws Exception {
         EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().build()).build();
 


### PR DESCRIPTION
Some of the changes to verify-saml-utils deleted a couple of classes
that are used by the Hub (through hub-saml):
- `OrganizationUnmarshaller` is used to build an `Organization` element in
the deprecated `/metadata/sp` endpoint
- `ContactPersonsUnmarshaller` is used to fill in a `ContactPersons`
element in the deprecated `/metadata/sp` endpoint

These elements don't provide any practical purpose for the Verify
federation so it is fine to remove all calls to these classes.