### PR TITLE
firebreak: use latest saml-libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 ext {
     opensaml_version = '3.3.0'
     ida_utils_version = '2.0.0-313'
-    saml_libs_version = "${opensaml_version}-103"
+    saml_libs_version = "${opensaml_version}-107"
 }
 
 subprojects {


### PR DESCRIPTION
Now passing in a metadata signature validator into the transformer
factory, which can be easily built in our client apps