### PR TITLE
firebreak: use signature validation support code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 ext {
     opensaml_version = '3.3.0'
     ida_utils_version = '2.0.0-313'
-    saml_libs_version = "${opensaml_version}-103"
+    saml_libs_version = "${opensaml_version}-107"
 }
 
 subprojects {

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStore.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStore.java
@@ -25,6 +25,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * @deprecated Use {@link uk.gov.ida.saml.security.MetadataBackedSignatureValidator} instead
+ */
+@Deprecated
 public class HubMetadataPublicKeyStore implements InternalPublicKeyStore {
 
     private final MetadataResolver metadataResolver;

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStore.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStore.java
@@ -30,6 +30,11 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Throwables.propagate;
 
+
+/**
+ * @deprecated Use {@link uk.gov.ida.saml.security.MetadataBackedSignatureValidator} instead
+ */
+@Deprecated
 public class IdpMetadataPublicKeyStore implements SigningKeyStore {
 
     private final MetadataResolver metadataResolver;


### PR DESCRIPTION
Now passing in a  signature validator into the transformer factory.

Methods that will only be called by Compliance Tool are now marked as deprecated.